### PR TITLE
Add device tree binding for D/AVE2D

### DIFF
--- a/zephyr/dts/bindings/tes,dave2d.yaml
+++ b/zephyr/dts/bindings/tes,dave2d.yaml
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Alif Semiconductor
+
+description: TES D/AVE 2D Graphics Accelerator
+
+compatible: "tes,dave2d"
+
+include: [base.yaml]
+
+properties:
+  reg:
+    required: true
+
+  interrupts:
+    required: true
+
+  clocks:
+    required: true

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -3,3 +3,5 @@ name: dave2d
 build:
   cmake: zephyr
   kconfig: zephyr/Kconfig
+  settings:
+    dts_root: zephyr


### PR DESCRIPTION
This pull request introduces device tree support for the D/AVE2D Graphics Accelerator and updates the module configuration to improve integration with Zephyr's build system.

Device Tree Support:

* Added a new device tree binding file `tes,dave2d.yaml` defining required properties (`reg`, `interrupts`, and `clocks`) for the D/AVE 2D Graphics Accelerator. ([zephyr/dts/bindings/tes,dave2d.yamlR1-R19](diffhunk://#diff-9e314e47c8c9e790f428ca8402d9c5ec3cb85a23cf626e31efaa7d74a5266f83R1-R19))

Build System Integration:

* Updated `module.yml` to set the `dts_root` to `zephyr`, ensuring correct discovery of device tree bindings during the build process.