### PR TITLE
Add support for using framebuffer from DTCM

### DIFF
--- a/d1/inc/dave_base.h
+++ b/d1/inc/dave_base.h
@@ -1323,6 +1323,24 @@ extern const d1_displaycaps * d1_displaygetcaps( d1_device *handle );
 #endif /* Dx4 */
 
 /*--------------------------------------------------------------------------
+*   Function: d1_localtoglobal
+*
+*   Convert a CPU local address to global address for hardware access.
+*
+*   On Alif Ensemble, the M55 CPU uses local addresses to access memories
+*   such as DTCM, but the DAVE2D IP block requires global addresses to
+*   DMA-access the same memory.
+*
+*   Parameters:
+*     ptr - CPU local address
+*
+*   Returns:
+*     void * - corresponding global address accessible by DAVE2D hardware,
+*              or the original ptr if no translation is needed.
+*/
+extern void * d1_localtoglobal( const void *ptr );
+
+/*--------------------------------------------------------------------------
 *   Function: d1_createdifbo
 *
 *   Create a DI FBO for a given frame buffer.

--- a/d1/src/dave_base.c
+++ b/d1/src/dave_base.c
@@ -19,6 +19,7 @@
 #ifdef __ZEPHYR__
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/dt-bindings/clock/alif_ensemble_clocks.h>
+#include <soc_memory_map.h>
 #else
 #include "RTE_Components.h"
 #include CMSIS_device_header
@@ -223,3 +224,18 @@ void d1_setregister( d1_device *handle, int deviceid, int index, long value )
     }
 }
 
+//--------------------------------------------------------------------------
+//
+void * d1_localtoglobal( const void *ptr )
+{
+    if (ptr == NULL)
+    {
+        return NULL;
+    }
+
+#ifdef __ZEPHYR__
+    return (void *)local_to_global(ptr);
+#else
+    return (void *)LocalToGlobal((void *)ptr);
+#endif
+}

--- a/d2/src/dave_blit.c
+++ b/d2/src/dave_blit.c
@@ -55,6 +55,7 @@
 #include "dave_texture.h"
 #include "dave_registermap.h"
 #include "dave_box.h"
+#include "dave_base.h"
 
 /*--------------------------------------------------------------------------
  *
@@ -159,7 +160,7 @@ d2_s32 d2_setblitsrc( d2_device *handle, void *ptr, d2_s32 pitch, d2_s32 width, 
 
    ctx = D2_DEV(handle)->ctxselected;
 
-   ctx->blit_src    = ptr;
+   ctx->blit_src    = d1_localtoglobal(ptr);
    ctx->blit_pitch  = pitch;
    ctx->blit_width  = width;
    ctx->blit_height = height;

--- a/d2/src/dave_dlist.c
+++ b/d2/src/dave_dlist.c
@@ -48,6 +48,7 @@
 #include "dave_intern.h"
 #include "dave_dlist.h"
 #include "dave_memory.h"
+#include "dave_base.h"
 
 
 #define D2_EXECUTE_DLIST_NEEDWAIT defined
@@ -334,7 +335,7 @@ void d2_nextdlistblock_intern( d2_dlist *dlist )
          return;
       }
       /* insert next block address (fix jump) */
-      *patch = (d2_s32) dlist->currentblock->block;
+      *patch = (d2_s32) d1_localtoglobal(dlist->currentblock->block);
    }
    else if ((dlist->blocksize < 1) || (vidmemBlocks->slicesleft == 1))
    { /* 'low localmem' mode: the spare block for the jump is only needed in last slice */
@@ -1264,7 +1265,7 @@ d2_s32* d2_add_dlistlist_intern( const d2_device *handle, d2_dlist *dlist, const
       }
    }
 
-   dlist_list[pos] = (d2_s32)dlistaddress;
+   dlist_list[pos] = (d2_s32)d1_localtoglobal(dlistaddress);
    dlist->dlist_addresses_cur = (d2_s16) (pos + 1);
 
    return &dlist_list[pos];

--- a/d2/src/dave_rbuffer.c
+++ b/d2/src/dave_rbuffer.c
@@ -121,6 +121,7 @@
 #include "dave_intern.h"
 #include "dave_memory.h"
 #include "dave_rbuffer.h"
+#include "dave_base.h"
 
 
 /*--------------------------------------------------------------------------*/
@@ -664,6 +665,8 @@ extern d2_s32 d2_relocateframe( d2_device *handle, const void *ptr )
   
    D2_VALIDATE( handle, D2_INVALIDDEVICE );  /* PRQA S 3112 */ /* $Misra: #DEBUG_MACRO $*/
    D2_CHECKERR( ptr, D2_NOVIDEOMEM );        /* PRQA S 3112 */ /* $Misra: #DEBUG_MACRO $*/
+
+   ptr = d1_localtoglobal(ptr);
 
    d2_scratch2dlist_intern(handle);
 

--- a/d2/src/dave_texture.c
+++ b/d2/src/dave_texture.c
@@ -30,6 +30,7 @@
 #include "dave_driver.h"
 #include "dave_intern.h"
 #include "dave_texture.h"
+#include "dave_base.h"
 
 
 /*--------------------------------------------------------------------------
@@ -109,6 +110,8 @@ d2_s32 d2_settexture( d2_device *handle, void *ptr, d2_s32 pitch, d2_s32 width, 
    D2_CHECKERR( pitch >= 0, D2_VALUENEGATIVE );     /* PRQA S 4130, 3112 */ /* $Misra: #DEBUG_MACRO $*/
    D2_CHECKERR( width >= 0, D2_VALUENEGATIVE );     /* PRQA S 4130, 3112 */ /* $Misra: #DEBUG_MACRO $*/
    D2_CHECKERR( height >= 0, D2_VALUENEGATIVE );    /* PRQA S 4130, 3112 */ /* $Misra: #DEBUG_MACRO $*/
+
+   ptr = d1_localtoglobal(ptr);
 
    ctx = D2_DEV(handle)->ctxselected;
    ctx->internaldirty |= d2_dirty_material;

--- a/d2/src/dave_viewport.c
+++ b/d2/src/dave_viewport.c
@@ -27,6 +27,7 @@
 #include "dave_intern.h"
 #include "dave_viewport.h"
 #include "dave_dlist.h"
+#include "dave_base.h"
 
 /*--------------------------------------------------------------------------
  * Group: Clipping
@@ -197,6 +198,8 @@ d2_s32 d2_framebuffer( d2_device *handle, void *ptr, d2_s32 pitch, d2_u32 width,
 {
    d2_contextdata *ctx;
 
+   ptr = d1_localtoglobal(ptr);
+
    D2_VALIDATE( handle, D2_INVALIDDEVICE );       /* PRQA S 4130, 3112, 3453 */ /* $Misra: #DEBUG_MACRO $*/
    D2_CHECKERR( ptr, D2_NOVIDEOMEM );             /* PRQA S 4130, 3112, 3453 */ /* $Misra: #DEBUG_MACRO $*/
    D2_CHECKERR( width  > 1, D2_VALUETOOSMALL );   /* PRQA S 4130, 3112, 3453 */ /* $Misra: #DEBUG_MACRO $*/
@@ -253,13 +256,13 @@ d2_s32 d2_framebuffer( d2_device *handle, void *ptr, d2_s32 pitch, d2_u32 width,
 
    while(NULL != ctx)
    {
-      ctx->cr2mask = 
-         D2_DEV(handle)->fbstylemask | 
-         ctx->blendmask              | 
-         ctx->tbstylemask            | 
-         ctx->alphablendmask         | 
-         ctx->rlemask                | 
-         ctx->clutmask               | 
+      ctx->cr2mask =
+         D2_DEV(handle)->fbstylemask |
+         ctx->blendmask              |
+         ctx->tbstylemask            |
+         ctx->alphablendmask         |
+         ctx->rlemask                |
+         ctx->clutmask               |
          ctx->colkeymask             ;
 
       ctx = ctx->next;
@@ -342,7 +345,7 @@ d2_s32 d2_clipbbox_intern( const d2_devicedata *handle, d2_bbox *box )
        )
    {
       return 0;
-   } 
+   }
    else
    {
       /* box clipping */
@@ -369,4 +372,3 @@ d2_s32 d2_clipbbox_intern( const d2_devicedata *handle, d2_bbox *box )
       return 1;
    }
 }
-


### PR DESCRIPTION
In case of DTCM memory is used for framebuffer, DAVE must use the global address when accessing the memory.

This commit introduces d1_localtoglobal API to do the address translation.